### PR TITLE
Use offline registry library to generate minimum hive

### DIFF
--- a/internal/winapi/ofreg.go
+++ b/internal/winapi/ofreg.go
@@ -2,3 +2,4 @@ package winapi
 
 //sys ORCreateHive(key *syscall.Handle) (regerrno error) = offreg.ORCreateHive
 //sys ORSaveHive(key syscall.Handle, file *uint16, OsMajorVersion uint32, OsMinorVersion uint32) (regerrno error) = offreg.ORSaveHive
+//sys ORCloseHive(key *syscall.Handle) (regerrno error) = offreg.ORCloseHive

--- a/internal/winapi/ofregistry.go
+++ b/internal/winapi/ofregistry.go
@@ -1,0 +1,4 @@
+package winapi
+
+//sys ORCreateHive(key *syscall.Handle) (regerrno error) = offreg.ORCreateHive
+//sys ORSaveHive(key syscall.Handle, file *uint16, OsMajorVersion uint32, OsMinorVersion uint32) (regerrno error) = offreg.ORSaveHive

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -1,3 +1,3 @@
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go ofregistry.go

--- a/internal/winapi/winapi.go
+++ b/internal/winapi/winapi.go
@@ -1,3 +1,3 @@
 package winapi
 
-//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go ofregistry.go
+//go:generate go run ..\..\mksyscall_windows.go -output zsyscall_windows.go bindflt.go user.go console.go system.go net.go path.go thread.go jobobject.go logon.go memory.go process.go processor.go devices.go filesystem.go errors.go ofreg.go

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -44,6 +44,7 @@ var (
 	modiphlpapi   = windows.NewLazySystemDLL("iphlpapi.dll")
 	modadvapi32   = windows.NewLazySystemDLL("advapi32.dll")
 	modcfgmgr32   = windows.NewLazySystemDLL("cfgmgr32.dll")
+	modoffreg     = windows.NewLazySystemDLL("offreg.dll")
 
 	procBfSetupFilter                          = modbindfltapi.NewProc("BfSetupFilter")
 	procNetLocalGroupGetInfo                   = modnetapi32.NewProc("NetLocalGroupGetInfo")
@@ -78,6 +79,8 @@ var (
 	procNtOpenDirectoryObject                  = modntdll.NewProc("NtOpenDirectoryObject")
 	procNtQueryDirectoryObject                 = modntdll.NewProc("NtQueryDirectoryObject")
 	procRtlNtStatusToDosError                  = modntdll.NewProc("RtlNtStatusToDosError")
+	procORCreateHive                           = modoffreg.NewProc("ORCreateHive")
+	procORSaveHive                             = modoffreg.NewProc("ORSaveHive")
 )
 
 func BfSetupFilter(jobHandle windows.Handle, flags uint32, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) {
@@ -402,6 +405,22 @@ func RtlNtStatusToDosError(status uint32) (winerr error) {
 	r0, _, _ := syscall.Syscall(procRtlNtStatusToDosError.Addr(), 1, uintptr(status), 0, 0)
 	if r0 != 0 {
 		winerr = syscall.Errno(r0)
+	}
+	return
+}
+
+func ORCreateHive(key *syscall.Handle) (regerrno error) {
+	r0, _, _ := syscall.Syscall(procORCreateHive.Addr(), 1, uintptr(unsafe.Pointer(key)), 0, 0)
+	if r0 != 0 {
+		regerrno = syscall.Errno(r0)
+	}
+	return
+}
+
+func ORSaveHive(key syscall.Handle, file *uint16, OsMajorVersion uint32, OsMinorVersion uint32) (regerrno error) {
+	r0, _, _ := syscall.Syscall6(procORSaveHive.Addr(), 4, uintptr(key), uintptr(unsafe.Pointer(file)), uintptr(OsMajorVersion), uintptr(OsMinorVersion), 0, 0)
+	if r0 != 0 {
+		regerrno = syscall.Errno(r0)
 	}
 	return
 }

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -81,6 +81,7 @@ var (
 	procRtlNtStatusToDosError                  = modntdll.NewProc("RtlNtStatusToDosError")
 	procORCreateHive                           = modoffreg.NewProc("ORCreateHive")
 	procORSaveHive                             = modoffreg.NewProc("ORSaveHive")
+	procORCloseHive                            = modoffreg.NewProc("ORCloseHive")
 )
 
 func BfSetupFilter(jobHandle windows.Handle, flags uint32, virtRootPath *uint16, virtTargetPath *uint16, virtExceptions **uint16, virtExceptionPathCount uint32) (hr error) {
@@ -419,6 +420,14 @@ func ORCreateHive(key *syscall.Handle) (regerrno error) {
 
 func ORSaveHive(key syscall.Handle, file *uint16, OsMajorVersion uint32, OsMinorVersion uint32) (regerrno error) {
 	r0, _, _ := syscall.Syscall6(procORSaveHive.Addr(), 4, uintptr(key), uintptr(unsafe.Pointer(file)), uintptr(OsMajorVersion), uintptr(OsMinorVersion), 0, 0)
+	if r0 != 0 {
+		regerrno = syscall.Errno(r0)
+	}
+	return
+}
+
+func ORCloseHive(key *syscall.Handle) (regerrno error) {
+	r0, _, _ := syscall.Syscall(procORCloseHive.Addr(), 1, uintptr(unsafe.Pointer(key)), 0, 0)
 	if r0 != 0 {
 		regerrno = syscall.Errno(r0)
 	}


### PR DESCRIPTION
This change adds functions to generate valid, empty hives using the [offline registry library](https://learn.microsoft.com/en-us/windows/win32/devnotes/offline-registry-library-portal) (thanks @riverar!) and replaces ```ensureFile()```.

This should give you the same result as the code in this commit: https://github.com/TBBle/hcsshim/commit/035362c035c9cc644095a092c34f3afe4b0c0bb2

But without any keys at all, besides the root key.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>